### PR TITLE
ci: harden SockJS release environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,20 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Create release bot token
+        id: release-bot
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ vars.PUTIO_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.PUTIO_RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          token: ${{ steps.release-bot.outputs.token }}
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -78,9 +88,9 @@ jobs:
             @semantic-release/git
             conventional-changelog-conventionalcommits
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GIT_AUTHOR_NAME: devsputio
-          GIT_AUTHOR_EMAIL: devs@put.io
-          GIT_COMMITTER_NAME: devsputio
-          GIT_COMMITTER_EMAIL: devs@put.io
+          GIT_AUTHOR_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
+          GIT_AUTHOR_EMAIL: ${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
+          GIT_COMMITTER_EMAIL: ${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       - verify
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    environment: release
     permissions:
       contents: write
       issues: write
@@ -51,21 +52,23 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - name: Set up Vite+
-        uses: voidzero-dev/setup-vp@v1
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: ".node-version"
-          cache: true
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install dependencies
-        run: vp install
+        run: pnpm install --frozen-lockfile
 
       - name: Release package
-        uses: cycjimmy/semantic-release-action@v6
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         with:
           extra_plugins: |
             @semantic-release/commit-analyzer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,9 @@ vp run test:integration
 
 GitHub Actions publishes from `main` through the protected `release` Environment.
 
-Keep `NPM_TOKEN` in that Environment with required reviewers and prevent self-review enabled, not as a plain repository secret. Pull request checks stay secretless and only run verify jobs.
+Keep `NPM_TOKEN`, `PUTIO_RELEASE_BOT_APP_ID`, and `PUTIO_RELEASE_BOT_PRIVATE_KEY` in that Environment with required reviewers and prevent self-review enabled, not as plain repository secrets. Pull request checks stay secretless and only run verify jobs.
 
-Trusted put.io team members may push directly to `main`, but repository rules should block outsiders, force-pushes, and branch deletes where GitHub plan support allows. Restrict `v*` tag creation or updates to release automation and release admins.
+Release GitHub writes use `putio-release-bot` for version sync commits, `v*` tags, GitHub Releases, and npm release notes. Trusted put.io team members may push directly to `main`, but repository rules should block outsiders, force-pushes, and branch deletes where GitHub plan support allows.
 
 ## Development Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,14 @@ Run it manually when you want extra confidence in the real SockJS handshake path
 vp run test:integration
 ```
 
+## Release Publishing
+
+GitHub Actions publishes from `main` through the protected `release` Environment.
+
+Keep `NPM_TOKEN` in that Environment with required reviewers and prevent self-review enabled, not as a plain repository secret. Pull request checks stay secretless and only run verify jobs.
+
+Trusted put.io team members may push directly to `main`, but repository rules should block outsiders, force-pushes, and branch deletes where GitHub plan support allows. Restrict `v*` tag creation or updates to release automation and release admins.
+
 ## Development Notes
 
 - Prefer `vp` for day-to-day commands.


### PR DESCRIPTION
## Summary

## Changed
- Move package publishing behind the protected release environment
- Use putio-release-bot for release writes and version bump commits

## Risks
- Release jobs depend on PUTIO_RELEASE_BOT_APP_ID and PUTIO_RELEASE_BOT_PRIVATE_KEY being present in the release Environment

## Verification
- actionlint passes locally for the touched workflow
- CI will verify the branch

## Complexity
- Neutral: release identity wiring is explicit but follows the shared put.io pattern