### PR TITLE
chore(release): align package.json with published v5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@putdotio/socket-client",
-  "version": "4.4.2",
+  "version": "5.0.0",
   "description": "SockJS client for real-time put.io events.",
   "keywords": [
     "put.io",


### PR DESCRIPTION
## Problem

`package.json` says `4.4.2` while npm and GitHub releases sit at v5.0.0, and no `chore: release` write-back commit exists in history. Every consumer-facing version string and `vp pack` output is a full major behind.

## Root cause

Same defect as [pas-js#41](https://github.com/putdotio/pas-js/pull/41). The v5.0.0 release (2026-03-19) ran semantic-release with **no configuration**: the repo had no `.releaserc.json` and no `release` key in `package.json`. The workflow passed `@semantic-release/git` through the action's `extra_plugins` input, but `extra_plugins` only *installs* packages — it does not add them to the plugin chain. semantic-release therefore ran its default plugin set (`commit-analyzer`, `release-notes-generator`, `npm`, `github`), which excludes the git plugin, so the version write-back never executed.

The later `.releaserc.json` configures `@semantic-release/git` correctly, and the release job now matches [putio-sdk-typescript](https://github.com/putdotio/putio-sdk-typescript), where write-back commits provably land (`chore(sdk): release 11.2.0 [skip ci]`, `package.json` = npm = 11.2.0). No release-triggering commit has landed here since March (only `chore`/`ci`/`build`), so the pipeline never got a chance to self-heal the stale version.

## Solution

Align `package.json` to the published v5.0.0. semantic-release computes the next version from the `v5.0.0` git tag (on `main`), so the next `fix`/`feat` release computes correctly and its write-back commit will land through the already-fixed pipeline.

`chore` commit type on purpose: merging this does not trigger a no-op publish.

## Verification

`vp run verify` green locally: 3 test files, 10 tests passed.

Fixes #58