### PR TITLE
fix(ci): keep lockfile maintenance from bumping manifest ranges

### DIFF
--- a/.github/workflows/lockfile-maintenance.yml
+++ b/.github/workflows/lockfile-maintenance.yml
@@ -62,8 +62,20 @@ jobs:
         with:
           node-version-file: .node-version
 
+      # --no-save keeps package.json and the lockfile's specifier records at
+      # their committed values; without it pnpm 11 update rewrites both and a
+      # lockfile-only commit fails frozen installs with a specifier mismatch.
       - name: Refresh transitive lockfile resolutions
-        run: corepack pnpm update --lockfile-only -r
+        run: corepack pnpm update --no-save --lockfile-only -r
+
+      - name: Assert only the lockfile changed
+        run: |
+          set -euo pipefail
+          if ! git diff --quiet -- ':(exclude)pnpm-lock.yaml'; then
+            echo "unexpected working-tree changes beyond pnpm-lock.yaml:" >&2
+            git status --porcelain >&2
+            exit 1
+          fi
 
       - name: Open or update pull request
         env:


### PR DESCRIPTION
## Summary

The first end-to-end lockfile-maintenance run produced a PR that fails frozen installs ([taizn#64](https://github.com/putdotio/taizn/pull/64), [run 32329772704](https://github.com/putdotio/taizn/actions/runs/32329772704)): `specifiers in the lockfile don't match specifiers in package.json`.

Mechanism (reproduced on pristine taizn manifests): untargeted `pnpm update --lockfile-only -r` on pnpm 11 rewrites `package.json` ranges **and** the lockfile's specifier records for direct deps with newer in-range versions; the workflow committed only `pnpm-lock.yaml`, guaranteeing the mismatch.

Fix: add `--no-save` — it keeps the manifest and specifier records at their committed values while still refreshing direct and transitive resolutions in range. Proven on the same scratch: `ws` 8.21.3, `@types/node` 26.2.0, `postcss` 8.5.26 resolved with specifiers unchanged (`^8.21.0` / `^26.1.0`), and `pnpm install --frozen-lockfile` passes. The untargeted `--no-save` form is not affected by the pnpm/pnpm#12744 no-op (that bug is specific to targeted `pkg@version` specs).

Also adds a tripwire step failing the run if anything beyond `pnpm-lock.yaml` is dirty after the refresh.

## Verification

- Scratch proof above; actionlint clean; verify runs on this PR.
- Identical delta applied across all 8 repos.

## Notes

Refs putdotio/putio-frontend#29
